### PR TITLE
Fix Dockerfile: remove RUN from distroless stage, support local build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@
 
 # --- Multi-arch static build for amd64/arm64 ---
 ARG TARGETARCH
-FROM rust:nightly AS builder
+FROM rust:latest AS builder
 
 # Map Docker TARGETARCH to Rust musl target triple
 ARG TARGETARCH


### PR DESCRIPTION
## What does this PR do?

## Why is this change needed?

## How was it tested?

## Checklist
- [ ] `cargo test` passes
- [ ] `cargo clippy` clean
- [ ] `cargo fmt` applied
- [ ] Related issue linked above
